### PR TITLE
Add basic implementation of model-view-controller mechanism for ProcMod(R) and ProcEvents

### DIFF
--- a/HelpSource/Classes/ProcEvents.schelp
+++ b/HelpSource/Classes/ProcEvents.schelp
@@ -519,7 +519,6 @@ f = {|events| //pass ProcEvents as an argument
 		thisView.onClose_{controller.remove}; //important to remove on close
 	});
 	view.layout.add(nil); //space at the end
-	// View(view).minHeight_(100); //space at the end
 };
 )
 

--- a/HelpSource/Classes/ProcEvents.schelp
+++ b/HelpSource/Classes/ProcEvents.schelp
@@ -7,6 +7,8 @@ DESCRIPTION::
 A structure for controlling modular processes.
 
 
+ProcEvents will update the state of another object in a model-view-controller paradigm (see link::Classes/SimpleController::). Currently implemented messages are code::\indexPlaying:: and code::\amp::. See link::Classes/ProcEvents#Model-view-controller examples::.
+
 CLASSMETHODS::
 
 METHOD:: buildFromFile
@@ -15,7 +17,7 @@ ARGUMENT:: procdict
 
 ARGUMENT:: tolerance
 
-ARGUMENT::  ... paths
+ARGUMENT:: ... paths
 
 
 METHOD:: initClass
@@ -397,4 +399,128 @@ s.waitForBoot({
 )
 
 s.scope
+::
+
+section:: Model-view-controller examples
+code::
+s.boot;
+
+(
+SynthDef(\singrain, {arg freq, amp, dur, procbus, outbus = 0;
+	    Out.ar(outbus,
+		        Pan2.ar(
+			            SinOsc.ar(freq, 0, amp) *
+			                EnvGen.kr(Env.sine(dur, amp), doneAction: 2) *
+			                In.kr(procbus), // read off the overall env control of the ProcMod
+			            Rand(-1.0, 1.0)
+		        )
+	    )
+}).add;
+)
+
+(
+// create a ProcMod... feed the function in at init time
+// for using a gui, it's important to define proc's id
+a = ProcMod.new(Env([0, 1, 0], [1, 1], \sin, 1), 0.02, \proc_a)
+        .function_({arg group, envbus, server;
+	            Task({
+		                inf.do({
+			                    s.sendMsg(\s_new, \singrain, s.nextNodeID, 0, group,
+				                        \freq, 440.rrand(880), \amp, 1, \dur, 0.2,
+				                        \procbus, envbus);
+			                    0.05.wait;
+		                    })
+	                });
+            }
+        );
+
+// create a ProcMod... set the function after init time
+b = ProcMod.new(Env([0, 1, 0], [1, 1], \sin, 1), 0.02, \proc_b)
+    .function_({arg group, envbus;
+	        Task({
+		            inf.do({
+			                s.sendMsg(\s_new, \singrain, s.nextNodeID, 0, group,
+				                    \freq, 4400.rrand(8800), \amp, 1, \dur, 0.2,
+				                    \procbus, envbus);
+			                0.05.wait;
+		                })
+	            });
+        });
+
+// create the ProcEvents to run the above ProcMods
+e = ProcEvents.new(
+	    // an array of event / release arrays
+	    [
+		        // run 'a'
+		/* 0 */        [a, nil],
+		        // run 'b'
+		/* 1 */        [b, nil],
+		        // kill ev1 and ev2
+		/* 2 */        [nil, [a, b]]
+    ], 1);
+
+//create another gui for procmods and event number
+f = {|events| //pass ProcEvents as an argument
+	var win, view, scroll, evArr;
+	var procIndexView, evController;
+
+	win = Window.new("All ProcMods", Rect(0, 0, 500, Window.screenBounds.height)).front;
+
+	win.view.layout_(VLayout(
+		HLayout(
+			StaticText().string_("current event: ").font_(Font(size: 24)).fixedWidth_(220).align_(\right),
+			procIndexView = StaticText().font_(Font(size: 32)).fixedWidth_(100),
+			nil
+		)
+	).margins_([0,0,0,0]));
+
+	//SimpleController for ProcEvents
+	evController = SimpleController(events);
+	evController.put(\indexPlaying, {|theChanger, what, values| //values will be event's index when playing and nil when everything's released/stopped
+		// what.post; ": ".post; values.postln;
+		procIndexView.string_(values.asString); //this will be nil when no events are playing
+	});
+	evController.put(\amp, {|theChanger, what, values| //only posting
+		"events' global amp: ".post; values.ampdb.round(0.1).post; " dB".postln;
+	});
+
+	//scrollable view with all procmods
+	scroll = ScrollView(win, win.bounds.width@win.bounds.height);
+	view = View();
+	scroll.canvas = view;
+	view.layout_(VLayout());
+	// StaticText(win).string_();
+	evArr = events.eventArray;
+	evArr.flat.do({|key, inc|
+		var thisProc = events.eventDict[key];
+		var runButt, sl, thisView;
+		var controller = SimpleController(thisProc); //SimpleController for each individual procmod
+		thisView = View(view).layout_(HLayout(
+			runButt = Button(view).states_([[key ++ " [ ]", Color.black], [key ++ " >", Color.black, Color.green(0.75, 0.25)]]).action_({|butt| if(butt.value.asBoolean, {thisProc.play}, {thisProc.release})}).fixedWidth_(220),
+		).margins_([0,0,0,0]));
+		sl = EZSlider(win, controlSpec: ControlSpec(-90, 6, \db, default: thisProc.amp.ampdb), action: {|sl| thisProc.amp_(sl.value.dbamp)});
+		thisView.layout.add(sl.sliderView);
+		thisView.layout.add(sl.numberView.fixedWidth_(50));
+
+		//update values automatically
+		controller.put(\isRunning, {|theChanger, what, values| //values will be true or false
+			// what.post; ": ".post; values.postln;
+			runButt.value_(values.asInteger);
+		});
+		controller.put(\amp, {|theChanger, what, values| //values will be current amp
+			// what.post; ": ".post; values.postln;
+			sl.value(values.ampdb);
+		});
+		thisView.onClose_{controller.remove}; //important to remove on close
+	});
+	view.layout.add(nil); //space at the end
+	// View(view).minHeight_(100); //space at the end
+};
+)
+
+//create a custom gui, as well as regular procEvents' perfGUI
+(
+f.value(e);
+e.perfGUI;
+)
 ::

--- a/HelpSource/Classes/ProcEvents.schelp
+++ b/HelpSource/Classes/ProcEvents.schelp
@@ -7,7 +7,7 @@ DESCRIPTION::
 A structure for controlling modular processes.
 
 
-ProcEvents will update the state of another object in a model-view-controller paradigm (see link::Classes/SimpleController::). Currently implemented messages are code::\indexPlaying:: and code::\amp::. See link::Classes/ProcEvents#Model-view-controller examples::.
+ProcEvents will update the state of another object in a model-view-controller paradigm (see link::Classes/SimpleController::). Currently implemented messages are code::\indexPlaying:: and code::\amp::. See link::#Model-view-controller examples::.
 
 CLASSMETHODS::
 
@@ -420,8 +420,8 @@ SynthDef(\singrain, {arg freq, amp, dur, procbus, outbus = 0;
 
 (
 // create a ProcMod... feed the function in at init time
-// for using a gui, it's important to define proc's id
-a = ProcMod.new(Env([0, 1, 0], [1, 1], \sin, 1), 0.02, \proc_a)
+// when planning to create a gui, it's important to define procs' IDs
+a = ProcMod.new(Env([0, 1, 0], [1, 1], \sin, 1), -30.dbamp, \proc_a)
         .function_({arg group, envbus, server;
 	            Task({
 		                inf.do({
@@ -435,7 +435,7 @@ a = ProcMod.new(Env([0, 1, 0], [1, 1], \sin, 1), 0.02, \proc_a)
         );
 
 // create a ProcMod... set the function after init time
-b = ProcMod.new(Env([0, 1, 0], [1, 1], \sin, 1), 0.02, \proc_b)
+b = ProcMod.new(Env([0, 1, 0], [1, 1], \sin, 1), -30.dbamp, \proc_b)
     .function_({arg group, envbus;
 	        Task({
 		            inf.do({
@@ -483,6 +483,7 @@ f = {|events| //pass ProcEvents as an argument
 	evController.put(\amp, {|theChanger, what, values| //only posting
 		"events' global amp: ".post; values.ampdb.round(0.1).post; " dB".postln;
 	});
+	win.onClose_({evController.remove}); //important to remove on close
 
 	//scrollable view with all procmods
 	scroll = ScrollView(win, win.bounds.width@win.bounds.height);
@@ -496,7 +497,11 @@ f = {|events| //pass ProcEvents as an argument
 		var runButt, sl, thisView;
 		var controller = SimpleController(thisProc); //SimpleController for each individual procmod
 		thisView = View(view).layout_(HLayout(
-			runButt = Button(view).states_([[key ++ " [ ]", Color.black], [key ++ " >", Color.black, Color.green(0.75, 0.25)]]).action_({|butt| if(butt.value.asBoolean, {thisProc.play}, {thisProc.release})}).fixedWidth_(220),
+			runButt = Button(view)
+			.states_([[key ++ " [ ]", Color.black], [key ++ " >", Color.black, Color.green(0.75, 0.25)]])
+			.action_({|butt| if(butt.value.asBoolean, {thisProc.play}, {thisProc.release})})
+			.fixedWidth_(220)
+			.value_(thisProc.isRunning.asInteger),
 		).margins_([0,0,0,0]));
 		sl = EZSlider(win, controlSpec: ControlSpec(-90, 6, \db, default: thisProc.amp.ampdb), action: {|sl| thisProc.amp_(sl.value.dbamp)});
 		thisView.layout.add(sl.sliderView);

--- a/HelpSource/Classes/ProcEvents.schelp
+++ b/HelpSource/Classes/ProcEvents.schelp
@@ -486,10 +486,10 @@ f = {|events| //pass ProcEvents as an argument
 	win.onClose_({evController.remove}); //important to remove on close
 
 	//scrollable view with all procmods
-	scroll = ScrollView(win, win.bounds.width@win.bounds.height);
+	scroll = ScrollView(win);
 	view = View();
 	scroll.canvas = view;
-	view.layout_(VLayout());
+	view.layout_(VLayout().spacing_(2));
 	// StaticText(win).string_();
 	evArr = events.eventArray;
 	evArr.flat.do({|key, inc|
@@ -503,7 +503,7 @@ f = {|events| //pass ProcEvents as an argument
 			.fixedWidth_(220)
 			.value_(thisProc.isRunning.asInteger),
 		).margins_([0,0,0,0]));
-		sl = EZSlider(win, controlSpec: ControlSpec(-90, 6, \db, default: thisProc.amp.ampdb), action: {|sl| thisProc.amp_(sl.value.dbamp)});
+		sl = EZSlider(view, controlSpec: ControlSpec(-90, 6, \db, default: thisProc.amp.ampdb), action: {|sl| thisProc.amp_(sl.value.dbamp)});
 		thisView.layout.add(sl.sliderView);
 		thisView.layout.add(sl.numberView.fixedWidth_(50));
 

--- a/HelpSource/Classes/ProcMod.schelp
+++ b/HelpSource/Classes/ProcMod.schelp
@@ -1,12 +1,12 @@
 TITLE:: ProcMod
 summary:: A real-time control structure
 categories:: Libraries>JoshUGens
-related:: Classes/ProcModR, Classes/ProcEvent
+related:: Classes/ProcModR, Classes/ProcEvents
 
 DESCRIPTION::
 A structure for controlling modular processes.
 
-
+ProcMod will update the state of another object in a model-view-controller paradigm (see link::Classes/SimpleController::). Currently implemented messages are code::\isRunning:: and code::\amp::. See link::Classes/ProcEvents#Model-view-controller examples::.
 CLASSMETHODS::
 
 METHOD:: initClass

--- a/HelpSource/Classes/ProcModR.schelp
+++ b/HelpSource/Classes/ProcModR.schelp
@@ -6,6 +6,8 @@ related:: Classes/ProcMod, Classes/ProcEvents
 DESCRIPTION::
 A structure for controlling modular processes, with the capabilitiy to record its output in real-time.
 
+ProcModR will update the state of another object in a model-view-controller paradigm (see link::Classes/SimpleController::). Currently implemented messages are code::\isRunning:: and code::\amp::. See link::Classes/ProcEvents#Model-view-controller examples::.
+
 
 CLASSMETHODS::
 


### PR DESCRIPTION
This PR adds functionality according to the model-view-controller paradigm, so the ProcMod(R) and ProcEvents will notify a controller (e.g. SimpleController) on actions like play, release and amplitude change.

It does not change the current behavior, but adds the ability to easily build custom GUIs for ProcMod/ProcEvents. New functionality is mentioned in respective help files and working example is included in the ProcEvents help file.

This PR also fixes some minor typos in the help.

CC @joshpar 