### PR TITLE
ProcEvents.perfGUI: convert event index to integer

### DIFF
--- a/ProcMod.sc
+++ b/ProcMod.sc
@@ -1261,7 +1261,7 @@ ProcEvents {
 					this.play(numboxval);
 					window.view.children[numbox].value_(numboxval + 1);
 					window.view.children[window.view.children.indexOf(me)+1]
-						.string_("Current Event: "++numboxval);
+						.string_("Current Event: "++numboxval.asInteger);
 					}, {
 					"No event at that index".warn
 					})


### PR DESCRIPTION
Forces event number to be an Int in perfGUI. Needed for SC 3.10+.