### PR TITLE
ProcModR: fix for id = nil

### DIFF
--- a/ProcMod.sc
+++ b/ProcMod.sc
@@ -534,7 +534,7 @@ ProcModR : ProcMod {
 		var thisfun, port;
 		clock = clock ?? {uniqueClock = true; TempoClock.new(tempo)};
 		isRunning.not.if({
-			ampOscDef = OSCdef(id, {arg ... args; (peakView.notNil and:{args[0][1] == envnode}).if({
+			ampOscDef = OSCdef(id ? this.hash, {arg ... args; (peakView.notNil and:{args[0][1] == envnode}).if({
 				{
 					var msg, peaks, amps;
 					msg = args[0];


### PR DESCRIPTION
`ProcModR` would not record if the `id` is `nil`. This PR allows using `ProcModR` with `id` being `nil`.

This is a fix that works for me but I'm not sure if there are any other implications of it. @joshpar how does this look to you?

Without this fix, at least one of the examples in the help is broken:
```supercollider
s.boot;
(
SynthDef(\singrain, {arg outbus, freq, amp, dur;
	OffsetOut.ar(outbus,
		Pan2.ar(
			SinOsc.ar(freq, 0, amp) *
			EnvGen.kr(Env.sine(dur, amp), doneAction: 2),
			Rand.new(-1.0, 1.0)
		)
	) // read off the overall env control of the ProcMod
}).add;
)

(
a = {arg amp, env, high, low, winsize, overlaps, path;
	var proc;
	// defaults to Server.default if no Server is supplied
	proc = ProcModR.new(env, amp, 2, 0);
	proc.recordPM(path);
	proc.function_({arg group, routebus, server;
		Task({
			inf.do({
				// start a new synth... run it inside this ProcMod's group,
				// and read control values off the envbus
				server.sendMsg(\s_new, \singrain, server.nextNodeID, 0, group,
					\freq, high.rrand(low), \amp, 1, \dur, winsize,
					\outbus, routebus);
				(winsize / overlaps).wait;
			})
		});
	});
};
)
// create new instances of ProcMod... store it to the variables 'b' and 'c'
b = a.value(0.2, Env([0, 1, 0], [1, 1], \sin, 1), 2000, 1000, 0.1, 4, "~/Desktop/test1".standardizePath); // a base path, other time stamp info is added
c = a.value(0.3, Env([0, 1, 0], [10, 0.1], [5, -10], 1), 440, 880, 0.4, 2, "~/Desktop/test2".standardizePath);

b.play; c.play;

b.release;
c.release;
```
