### PR TITLE
ProcMod - Midi control updates

### DIFF
--- a/HelpSource/Classes/ProcMod.schelp
+++ b/HelpSource/Classes/ProcMod.schelp
@@ -154,7 +154,7 @@ Minimum amplitude in dB (for MIDI value of code::0::)
 
 ARGUMENT:: clientPort
 If not code::nil::, CC will be sent back to this port whenever code::amp_:: is being updated. Useful for MIDI controllers that can update its state when receiving CC messages (e.g. having endless encoders with LED rings or motorized faders).
-The argument can be a code::MIDIEndPoint:: to specify a particular port reliably or an code::Integer:: specifying a device in the code::MIDIClient.destination:: array.
+The argument can be an instance of code::MIDIOut:: or code::MIDIEndPoint:: to specify a particular port reliably or an code::Integer:: specifying a device index in the code::MIDIClient.destination:: array.
 The messages are sent on the same channel to the same CC number as specified for receiving.
 
 ARGUMENT:: midiChannel

--- a/HelpSource/Classes/ProcMod.schelp
+++ b/HelpSource/Classes/ProcMod.schelp
@@ -139,17 +139,26 @@ ARGUMENT:: newtimeScale
 METHOD:: clock
 
 METHOD:: mapAmpToCC
+Map MIDI continuous controller to the amplitude of this ProcMod. The messages are received from all MIDI sources.
 
+Note:: Be sure to run code::MIDIClient.init:: before calling this method.::
 
 ARGUMENT:: control
+CC number
 
 ARGUMENT:: maxamp
+Maximum amplitude in dB (for MIDI value of code::127::)
 
 ARGUMENT:: minamp
+Minimum amplitude in dB (for MIDI value of code::0::)
 
 ARGUMENT:: clientPort
+If not code::nil::, CC will be sent back to this port whenever code::amp_:: is being updated. Useful for MIDI controllers that can update its state when receiving CC messages (e.g. having endless encoders with LED rings or motorized faders).
+The argument can be a code::MIDIEndPoint:: to specify a particular port reliably or an code::Integer:: specifying a device in the code::MIDIClient.destination:: array.
+The messages are sent on the same channel to the same CC number as specified for receiving.
 
 ARGUMENT:: midiChannel
+Channel to receive and send the messages on.
 
 METHOD:: releaseFunc
 An instance of Function, Task or Routine to be evaluated after a ProcMod has released.

--- a/ProcMod.sc
+++ b/ProcMod.sc
@@ -61,12 +61,10 @@ ProcMod {
 			responder.notNil.if({responder.add});
 			midiAmp.if({
 				[midiChan, midiCtrl].postln;
-				ccCtrl = CCResponder({arg src, chan, num, value;
-					this.amp_(midiAmpSpec.map(value*0.0078740157480315).dbamp, false);
-					}, nil, midiChan, midiCtrl, nil);
 				port = MIDIOut.new(midiPort);
 				port.control(midiChan, midiCtrl, (midiAmpSpec.unmap(amp.ampdb) * 127).round);
-				});
+				this.prMakeCCResponder;
+			});
 			// create this Proc's group, and if there is an env, start it
 			// also, if there is no release node, schedule the Procs release
 			group = group ?? {server.nextNodeID};
@@ -298,12 +296,18 @@ ProcMod {
 		midiPort = clientPort;
 		midiChan = midiChannel;
 		ccCtrl.notNil.if({
-			ccCtrl.remove;
-			ccCtrl = CCResponder({arg src, chan, num, value;
-				this.amp_(midiAmpSpec.map(value*0.0078740157480315).dbamp, false);
-				}, nil, midiChan, midiCtrl, nil)
-			})
-		}
+			this.prMakeCCResponder;
+		})
+	}
+
+	prMakeCCResponder {
+		var maxMidiValReci = 127.reciprocal;
+		ccCtrl.remove;
+		ccCtrl = CCResponder({arg src, chan, num, value;
+			this.amp_(midiAmpSpec.map(value * maxMidiValReci).dbamp, false);
+		}, nil, midiChan, midiCtrl, nil)
+	}
+
 
 	// ProcMod.gui should create a small GUI that will control the ProcMod - start / stop, amp
 	// if trig is notNil, it should be a $char or a midi keynum. This will toggle the ProcMod
@@ -545,9 +549,7 @@ ProcModR : ProcMod {
 			responder.notNil.if({responder.add});
 			midiAmp.if({
 				[midiChan, midiCtrl].postln;
-				ccCtrl = CCResponder({arg src, chan, num, value;
-					this.amp_(midiAmpSpec.map(value*0.0078740157480315).dbamp, false);
-					}, nil, midiChan, midiCtrl, nil);
+				this.prMakeCCResponder;
 				port = MIDIOut.new(midiPort);
 				port.control(midiChan, midiCtrl, (midiAmpSpec.unmap(amp.ampdb) * 127).round);
 				});

--- a/ProcMod.sc
+++ b/ProcMod.sc
@@ -290,13 +290,17 @@ ProcMod {
 		midiAmpSpec = [minamp, maxamp, \db].asSpec;
 		midiAmp = true;
 		midiCtrl = control;
-		if(clientPort.isKindOf(Integer), {
-			midiPort = MIDIOut(clientPort)
-		}, {
-			if(clientPort.isKindOf(MIDIEndPoint), {
-				midiPort = MIDIOut.newByName(clientPort.device, clientPort.name)
-			})
-		});
+		try {
+			if(clientPort.isKindOf(Integer), {
+				midiPort = MIDIOut(clientPort)
+			}, {
+				if(clientPort.isKindOf(MIDIEndPoint), {
+					midiPort = MIDIOut.newByName(clientPort.device, clientPort.name)
+				})
+			});
+		} {
+			"Failed to use '%' as MIDIOut".format(clientPort).warn;
+		};
 		midiChan = midiChannel;
 		ccCtrl.notNil.if({
 			this.prMakeCCResponder;

--- a/ProcMod.sc
+++ b/ProcMod.sc
@@ -65,7 +65,7 @@ ProcMod {
 					this.amp_(midiAmpSpec.map(value*0.0078740157480315).dbamp, false);
 					}, nil, midiChan, midiCtrl, nil);
 				port = MIDIOut.new(midiPort);
-				port.control(midiChan, midiCtrl, (midiAmpSpec.unmap(amp) * 127).round);
+				port.control(midiChan, midiCtrl, (midiAmpSpec.unmap(amp.ampdb) * 127).round);
 				});
 			// create this Proc's group, and if there is an env, start it
 			// also, if there is no release node, schedule the Procs release
@@ -128,7 +128,7 @@ ProcMod {
 		(midiAmp and: {sendMidi}).if({
 			port = MIDIOut.new(midiPort);
 			port.control(midiChan, midiCtrl,
-				(midiAmpSpec.unmap(amp) * 127).round.max(0).min(127));
+				(midiAmpSpec.unmap(amp.ampdb) * 127).round.clip(0, 127));
 			});
 		this.changed(\amp, amp);
 	}
@@ -549,7 +549,7 @@ ProcModR : ProcMod {
 					this.amp_(midiAmpSpec.map(value*0.0078740157480315).dbamp, false);
 					}, nil, midiChan, midiCtrl, nil);
 				port = MIDIOut.new(midiPort);
-				port.control(midiChan, midiCtrl, (midiAmpSpec.unmap(amp) * 127).round);
+				port.control(midiChan, midiCtrl, (midiAmpSpec.unmap(amp.ampdb) * 127).round);
 				});
 			group = group ?? {server.nextNodeID};
 			notegroup = server.nextNodeID;

--- a/ProcMod.sc
+++ b/ProcMod.sc
@@ -296,11 +296,16 @@ ProcMod {
 			}, {
 				if(clientPort.isKindOf(MIDIEndPoint), {
 					midiPort = MIDIOut.newByName(clientPort.device, clientPort.name)
+				}, {
+					if(clientPort.isKindOf(MIDIOut), {
+						midiPort = clientPort;
+					})
 				})
 			});
-		} {
-			"Failed to use '%' as MIDIOut".format(clientPort).warn;
 		};
+		if(clientPort.notNil && midiPort.isNil, {
+			"Failed to use '%' as MIDIOut".format(clientPort).warn;
+		});
 		midiChan = midiChannel;
 		ccCtrl.notNil.if({
 			this.prMakeCCResponder;


### PR DESCRIPTION
Fixed:
- amplitude value sent back to midi out had a wrong value (missing `.ampdb`)

Changed:
- midi receiving and sending code was refactored to avoid duplication
- `ProcMod -mapAmpToCC`'s argument `clientPort` value is not `nil` by default (previously it would default to the first midi output). I believe this is a better behavior - on my system IAC driver is the first MIDI device so I was getting the MIDI messages sent back unnecessarily. 
  - clientPort can now be not only an index into `MIDIOut.destinations` (as before), but also `MIDIEndPoint` and `MIDIOut` to specify a particular port reliably
- I did _not_ replace `CCResponder` with `OSCFunc`...

Updated:
- documentation for `ProcMod -mapAmpToCC`