### PR TITLE
Add ProcEvents -indexPlaying

### DIFF
--- a/HelpSource/Classes/ProcEvents.schelp
+++ b/HelpSource/Classes/ProcEvents.schelp
@@ -83,7 +83,7 @@ METHOD:: eventArray
 METHOD:: preKill
 
 METHOD:: next
-Will play and release the next event is the events array. Starts at 0. If initmod has not been executed, it will be.
+Will play and release the next event in the events array. Starts at 0. If initmod has not been executed, it will be.
 
 METHOD:: scope
 
@@ -103,6 +103,8 @@ METHOD:: timeStamp
 METHOD:: stopRecord
 
 METHOD:: index
+
+The emphasis::next:: event's index. This is used internally and only when there's no GUI.
 
 ARGUMENT:: nextIdx
 

--- a/HelpSource/Classes/ProcEvents.schelp
+++ b/HelpSource/Classes/ProcEvents.schelp
@@ -106,6 +106,10 @@ METHOD:: index
 
 ARGUMENT:: nextIdx
 
+METHOD:: indexPlaying
+
+Returns an code::Integer:: of the currently playing index. Will be code::nil:: initially and after resetting.
+
 
 METHOD:: bigNum
 

--- a/ProcMod.sc
+++ b/ProcMod.sc
@@ -790,7 +790,7 @@ ProcModR : ProcMod {
 //model-view-controller messages: \indexPlaying with the current index, \amp with global amp
 
 ProcEvents {
-	var <eventDict, <ampDict, <eventArray, <releaseArray, <timeArray, <index,
+	var <eventDict, <ampDict, <eventArray, <releaseArray, <timeArray, <index, <indexPlaying,
 		<id, gui = false, <window, <server, firstevent = false, initmod, killmod, <amp, <lag,
 		<procampsynth, procevscope = false, <pracwindow, <pracmode = false, pracdict,
 		<eventButton, <killButton, <releaseButton, starttime = nil, <pedal = false,
@@ -859,6 +859,7 @@ ProcEvents {
 		amp = argamp;
 		index = 0;
 		this.changed(\indexPlaying, nil);
+		indexPlaying = nil;
 		lag = arglag;
 		firstevent = true;
 		isPlaying = false;
@@ -926,6 +927,7 @@ ProcEvents {
 	play {arg event;
 		var path;
 		this.changed(\indexPlaying, event);
+		indexPlaying = event.asInteger;
 		firstevent.if({
 			isPlaying = true;
 			starttime.isNil.if({starttime = Main.elapsedTime});
@@ -990,7 +992,8 @@ ProcEvents {
 			});
 		tlplay.if({this.stopTimeLine});
 		tlrec.if({this.stopRecordTimeLine});
-		this.changed(\indexPlaying, nil)
+		this.changed(\indexPlaying, nil);
+		indexPlaying = nil;
 	}
 
 	reset {
@@ -1001,6 +1004,7 @@ ProcEvents {
 		firstevent = true;
 		index = 0;
 		this.changed(\indexPlaying, nil);
+		indexPlaying = nil;
 		lag = 0.1;
 		this.amp_(1);
 		gui.if({


### PR DESCRIPTION
Previously there was no variable (AFAICT) that was holding the currently playing index. 

I added a method `indexPlaying` that holds the value that's already propagated using the `.update`  mechanism.